### PR TITLE
学部3年メンバーに大島橙也を追加

### DIFF
--- a/members.html
+++ b/members.html
@@ -102,7 +102,7 @@
     <section id="year3" aria-labelledby="year3-h">
       <h2 id="year3-h">学部3年</h2>
       <ul class="member-list">
-        <li class="placeholder">（準備中 — メンバー情報は後日掲載します）</li>
+        <li>大島 橙也</li>
       </ul>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- `members.html` の学部3年セクションに大島橙也さんを掲載

## Test plan
- [ ] https://kklab.mobi/members.html で学部3年に「大島 橙也」が表示されること

EOF